### PR TITLE
Solve Undefined offset issue

### DIFF
--- a/src/GDTool.php
+++ b/src/GDTool.php
@@ -438,9 +438,9 @@ class GDTool implements GDToolContract {
 		}
 
 		return [
-			'red'   => hexdec($red),
-			'green' => hexdec($green),
-			'blue'  => hexdec($blue),
+			hexdec($red),
+			hexdec($green),
+			hexdec($blue),
 		];
 	}
 


### PR DESCRIPTION
The array should not be associative if you want to use its result with `list` function. This PR changes it to indexed array that solves  #1 issue.